### PR TITLE
Fix iOS 11 crash

### DIFF
--- a/engine/srciPhone/dEngineAppDelegate.m
+++ b/engine/srciPhone/dEngineAppDelegate.m
@@ -198,6 +198,13 @@ void Native_UploadScore(uint score)
 	NSLog(@"applicationDidFinishLaunching");
 	[[UIApplication sharedApplication] setStatusBarHidden:YES];
 	[UIApplication sharedApplication].idleTimerDisabled = YES;
+    
+    if (vc == nil)
+    {
+        vc = [UIViewController new];
+        
+    }
+    [self.window setRootViewController:vc];
 }
 
 - (void) applicationWillResignActive:(UIApplication *)application
@@ -264,14 +271,8 @@ void Native_LoginGameCenter(void)
 	NSLog(@"applicationDidBecomeActive");
 	engineDelegate = self;
 	this = self;
-	if (vc == nil)
-	{
-		vc = [UIViewController new];
-		
-	}
 	vc.view = [this glView];
-	[self.window setRootViewController:vc];
-	
+    
 	[glView checkEngineSettings];
 	
 	


### PR DESCRIPTION
The App Store version is crashing; after downloading the project, I saw this crash on startup:
"Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Application windows are expected to have a root view controller at the end of application launch'"

This small patch should fix the crash on iOS 11.